### PR TITLE
Fixes a race condition when restarting the muxer

### DIFF
--- a/include/gsm0710muxer/muxer_impl.h
+++ b/include/gsm0710muxer/muxer_impl.h
@@ -92,9 +92,7 @@ inline int Muxer<StreamT, MutexT>::notifyInput(size_t size) {
 
 template<typename StreamT, typename MutexT>
 inline int Muxer<StreamT, MutexT>::start(bool initiator) {
-    if (isRunning()) {
-        stop();
-    }
+    stop();
 
     LOG(INFO, "Starting GSM07.10 muxer");
 
@@ -159,13 +157,15 @@ inline int Muxer<StreamT, MutexT>::start(bool initiator) {
 
 template<typename StreamT, typename MutexT>
 inline int Muxer<StreamT, MutexT>::stop() {
-    if (!isRunning()) {
+    if (!isRunning() && !thread_) {
         return GSM0710_ERROR_NONE;
     }
 
     LOG(INFO, "Stopping GSM07.10 muxer");
 
-    xEventGroupSetBits(events_, EVENT_STOP);
+    if (isRunning()) {
+        xEventGroupSetBits(events_, EVENT_STOP);
+    }
     xEventGroupWaitBits(events_, EVENT_STOPPED, pdTRUE, pdFALSE, portMAX_DELAY);
 
     thread_ = nullptr;


### PR DESCRIPTION
When restarting the muxer, we should always call `stop()` and wait for `EVENT_STOPPED`, even if the muxer asynchronously exited due to keepalive timeout or by request from the peer.