### PR TITLE
Do not clear external non-muxer shared event groups events on start

### DIFF
--- a/include/gsm0710muxer/muxer_impl.h
+++ b/include/gsm0710muxer/muxer_impl.h
@@ -137,7 +137,7 @@ inline int Muxer<StreamT, MutexT>::start(bool initiator, bool openZeroChannel) {
             CHECK_TRUE(channelEvents_, GSM0710_ERROR_NO_MEMORY);
         }
 
-        xEventGroupClearBits(events_, EVENT_MAX - 1);
+        xEventGroupClearBits(events_, ~((0x01UL << GSM0710_EVENT_BASE) - 1));
         xEventGroupClearBits(channelEvents_,
                 ((EVENT_STATE_CHANGED << ((sizeof(channels_) / sizeof(channels_[0])) + 1)) - 1));
 


### PR DESCRIPTION
### Description

As title says when starting the muxer we should only clear our own events.