### PR TITLE
Fix: resume channel when device is powered cycle.

### DIFF
--- a/include/gsm0710muxer/muxer_impl.h
+++ b/include/gsm0710muxer/muxer_impl.h
@@ -410,19 +410,13 @@ inline int Muxer<StreamT, MutexT>::resumeChannel(uint8_t channel) {
 
     GSM0710_LOG_DEBUG(INFO, "Resuming channel %d", channel);
 
-    bool update = false;
-    {
-        std::lock_guard<MutexT> lk(mutex_);
+    std::lock_guard<MutexT> lk(mutex_);
 
-        const auto newState = (c->localModemState | ((proto::RTR | proto::RTC))) & ~(proto::FC);
-        if (newState != c->localModemState) {
-            c->localModemState = newState;
-            c->update = update = true;
-        }
-    }
-    if (update) {
-        xEventGroupSetBits(events_, EVENT_WAKEUP);
-    }
+    const auto newState = (c->localModemState | ((proto::RTR | proto::RTC))) & ~(proto::FC);
+    c->localModemState = newState;
+    c->update = true;
+
+    xEventGroupSetBits(events_, EVENT_WAKEUP);
 
     return 0;
 }

--- a/include/gsm0710muxer/muxer_impl.h
+++ b/include/gsm0710muxer/muxer_impl.h
@@ -410,11 +410,13 @@ inline int Muxer<StreamT, MutexT>::resumeChannel(uint8_t channel) {
 
     GSM0710_LOG_DEBUG(INFO, "Resuming channel %d", channel);
 
-    std::lock_guard<MutexT> lk(mutex_);
+    {
+        std::lock_guard<MutexT> lk(mutex_);
 
-    const auto newState = (c->localModemState | ((proto::RTR | proto::RTC))) & ~(proto::FC);
-    c->localModemState = newState;
-    c->update = true;
+        const auto newState = (c->localModemState | ((proto::RTR | proto::RTC))) & ~(proto::FC);
+        c->localModemState = newState;
+        c->update = true;
+    }
 
     xEventGroupSetBits(events_, EVENT_WAKEUP);
 


### PR DESCRIPTION
Always resume channel in case that device is powered cycle during channel is suspended. This issue may affect warm boot.